### PR TITLE
Add pre-commit-config with hooks: clang-format, remove-crlf, remove-t…

### DIFF
--- a/.clang_format.hook
+++ b/.clang_format.hook
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+readonly VERSION="13.0.0"
+
+version=$(clang-format -version)
+
+if ! [[ $(python -V 2>&1 | awk '{print $2}' | awk -F '.' '{print $1$2}') -ge 36 ]]; then
+    echo "clang-format installation by pip need python version great equal 3.6,
+          please change the default python to higher version."
+    exit 1
+fi
+
+if ! [[ $version == *"$VERSION"* ]]; then
+    # low version of pip may not have the source of clang-format whl
+    pip install --upgrade pip
+    pip install clang-format==13.0.0
+fi
+
+clang-format $@

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,24 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+    -   id: check-added-large-files
+        args: ['--maxkb=512']
+    -   id: check-case-conflict
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace
+        files: \.(c|cc|cxx|cpp|cu|h|hh|hpp|hxx)$
+-   repo: https://github.com/Lucas-C/pre-commit-hooks
+    rev: v1.5.5
+    hooks:
+    -   id: remove-crlf
+    -   id: remove-tabs
+        files: \.(c|cc|cxx|cpp|cu|h|hh|hpp|hxx)$
+-   repo: local
+    hooks:
+    -   id: clang-format
+        name: clang-format
+        description: Format files with ClangFormat
+        entry: bash .clang_format.hook -i
+        language: system
+        files: \.(c|cc|cxx|cpp|cu|h|hh|hpp|hxx|cuh|proto)$


### PR DESCRIPTION
…abs, check-added-large-files, check-case-conflict, end-of-file-fixer, trailing-whitespace

.clang_format and .clang-tidy may be needed(the default is good, but not compatible with this repo's code style), but I know little about them --- **HELP NEEDED!**